### PR TITLE
Missing pointer dereference

### DIFF
--- a/src/Lua.cpp
+++ b/src/Lua.cpp
@@ -97,7 +97,7 @@ static void get_host_vlan_info(char* lua_ip, char** host_ip,
   if(((*host_ip) = strtok_r(buf, "@", &where)) != NULL)
     vlan = strtok_r(NULL, "@", &where);
 
-  if(host_ip == NULL)
+  if(*host_ip == NULL)
     *host_ip = lua_ip;
 
   if(vlan)


### PR DESCRIPTION
Either the condition 'host_ip==NULL' is redundant or there is possible null pointer dereference: host_ip.